### PR TITLE
Bug fix to support multiple commas in BLIPVQA and ImageEditing.

### DIFF
--- a/visual_chatgpt.py
+++ b/visual_chatgpt.py
@@ -152,7 +152,7 @@ class ImageEditing:
         self.inpainting = StableDiffusionInpaintPipeline.from_pretrained("runwayml/stable-diffusion-inpainting",).to(device)
 
     def remove_part_of_image(self, input):
-        image_path, to_be_removed_txt = input.split(",")
+        image_path, to_be_removed_txt = inputs.split(",")[0], ','.join(inputs.split(',')[1:])
         print(f'remove_part_of_image: to_be_removed {to_be_removed_txt}')
         return self.replace_part_of_image(f"{image_path},{to_be_removed_txt},background")
 
@@ -789,7 +789,7 @@ class BLIPVQA:
         self.model = BlipForQuestionAnswering.from_pretrained("Salesforce/blip-vqa-base").to(self.device)
 
     def get_answer_from_question_and_image(self, inputs):
-        image_path, question = inputs.split(",")
+        image_path, question = inputs.split(",")[0], ','.join(inputs.split(',')[1:])
         raw_image = Image.open(image_path).convert('RGB')
         print(F'BLIPVQA :question :{question}')
         inputs = self.processor(raw_image, question, return_tensors="pt").to(self.device)


### PR DESCRIPTION
**Problem**:

There is a bug that BLIPVQA does not process input with multiple commas sometimes at `BLIPVQA.get_answer_from_question_and_image()`
There are similar behaviors in `ImageEditing`. 

**Exception**:
```
> Entering new AgentExecutor chain...                                                                                                                                
 Yes                                                                                                                                                                 
Action: Answer Question About The Image                                                                                                                              
Action Input: image/09b01664.png, Suppose the ball is falling down, what action should you take to catch the ball and bounce it back given the game rule?Traceback (m
ost recent call last):                                                                                                                                               
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/gradio/routes.py", line 384, in run_predict                                                 
    output = await app.get_blocks().process_api(                                                                                                                     
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/gradio/blocks.py", line 1032, in process_api                                                
    result = await self.call_function(                                                                                                                               
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/gradio/blocks.py", line 844, in call_function                                               
    prediction = await anyio.to_thread.run_sync(                                                                                                                     
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/anyio/to_thread.py", line 31, in run_sync                                                   
    return await get_asynclib().run_sync_in_worker_thread(                                                                                                           
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread                        
    return await future                                                                                                                                              
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 867, in run                                              
    result = context.run(func, *args)                                                                                                                                
  File "visual_chatgpt.py", line 908, in run_text                                                                                                                    
    res = self.agent({"input": text})                                                                                                                                
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/langchain/chains/base.py", line 168, in __call__                                            
    raise e                                                                                                                                                          
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/langchain/chains/base.py", line 165, in __call__                                            
    outputs = self._call(inputs)                                                                                                                                     
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/langchain/agents/agent.py", line 503, in _call                                              
    next_step_output = self._take_next_step(                                                                                                                         
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/langchain/agents/agent.py", line 420, in _take_next_step                                    
    observation = tool.run(
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/langchain/tools/base.py", line 71, in run
    raise e
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/langchain/tools/base.py", line 68, in run
    observation = self._run(tool_input)
  File "/home/jishang/miniconda3/envs/visgpt/lib/python3.8/site-packages/langchain/agents/tools.py", line 17, in _run
    return self.func(tool_input)
  File "visual_chatgpt.py", line 792, in get_answer_from_question_and_image
    image_path, question = inputs.split(",")
ValueError: too many values to unpack (expected 2)
```

**Fix**:

Being consistant with other VFM pipelines in visual-chatgpt, let us process input as 
```image_path, instruct_text = inputs.split(",")[0], ','.join(inputs.split(',')[1:])```

