### PR TITLE
fix: add opencv-python as required lib

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -3,6 +3,7 @@ torchvision==0.13.1
 numpy==1.23.1
 transformers==4.26.1
 albumentations==1.3.0
+opencv-python==4.5.1.48
 opencv-contrib-python==4.3.0.36
 imageio==2.9.0
 imageio-ffmpeg==0.4.2


### PR DESCRIPTION
Facing same issue https://github.com/microsoft/visual-chatgpt/issues/29

I believe that adding the `opencv-python` library to the requirements.txt file should work.

