### PR TITLE
make quick start more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ See our paper: [<font size=5>Visual ChatGPT: Talking, Drawing and Editing with V
 ## Quick Start
 
 ```
+# clone this repository
+git clone https://github.com/microsoft/visual-chatgpt.git
+
+# change into the new directory
+cd visual-chatgpt
+
 # create a new environment
 conda create -n visgpt python=3.8
 


### PR DESCRIPTION
I added that you first need to clone this repo and change into the directory after that.  Might seem obvious but I was not sure why the pip install -r requirements.txt failed at first.