### PR TITLE
Un necessary else statement after a return statement

### DIFF
--- a/visual_chatgpt.py
+++ b/visual_chatgpt.py
@@ -84,13 +84,12 @@ def cut_dialogue_history(history_memory, keep_last_n_words=500):
     print(f"hitory_memory:{history_memory}, n_tokens: {n_tokens}")
     if n_tokens < keep_last_n_words:
         return history_memory
-    else:
-        paragraphs = history_memory.split('\n')
-        last_n_tokens = n_tokens
-        while last_n_tokens >= keep_last_n_words:
-            last_n_tokens = last_n_tokens - len(paragraphs[0].split(' '))
-            paragraphs = paragraphs[1:]
-        return '\n' + '\n'.join(paragraphs)
+    paragraphs = history_memory.split('\n')
+    last_n_tokens = n_tokens
+    while last_n_tokens >= keep_last_n_words:
+        last_n_tokens = last_n_tokens - len(paragraphs[0].split(' '))
+        paragraphs = paragraphs[1:]
+    return '\n' + '\n'.join(paragraphs)
 
 def get_new_image_name(org_img_name, func_name="update"):
     head_tail = os.path.split(org_img_name)


### PR DESCRIPTION
Un necessary else statements after return statements are considered as bad coding practice. Following arguments would support the argument:

**1. Increases Code Complexity**: 
Including else statements after a return statement adds unnecessary code complexity, making it harder for other developers to understand the code. It can also increase the risk of introducing bugs, making the code more difficult to maintain.

**2. Redundant Code**: The code in the else block after a return statement will never execute because the return statement will exit the function. Therefore, the else block becomes redundant, leading to bloated code.

**3. Violates DRY Principle:** 
The "Don't Repeat Yourself" (DRY) principle is a best practice in software development that suggests avoiding duplicating code. Including an unnecessary else block after a return statement can be seen as violating the DRY principle because the code in the else block is essentially duplicated.

In summary, omitting unnecessary else statements after return statements can make the code cleaner, easier to understand, and more maintainable.