### PR TITLE
Quick fix for image not displayed,reverting to previous version of gr…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 langchain==0.0.101
 torch==1.12.1
 torchvision==0.13.1
+gradio==3.20.1
 accelerate
 addict
 albumentations
@@ -8,7 +9,6 @@ basicsr
 controlnet-aux
 diffusers
 einops
-gradio
 imageio
 imageio-ffmpeg
 invisible-watermark


### PR DESCRIPTION
The images are not displayed in the latest radio package (3.21.0, Released a few hours ago). This is a quick fix for that. We might need to stick with a specific version of gradio to avoid this error.
![gradio-images-not-displyed-issue](https://user-images.githubusercontent.com/3255994/224881697-6c602614-9dcc-4cef-9fe9-ee5d29bde88f.PNG)
