### PR TITLE
fix: Invalid langchain version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-langchain==0.0.101
+langchain==0.0.10
 torch==1.12.1
 torchvision==0.13.1
 gradio==3.20.1


### PR DESCRIPTION
An error occurred when pip install -r requirements.txt:

ERROR: Could not find a version that satisfies the requirement langchain==0.0.101 (from versions: 0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.0.6, 0.0.7, 0.0.8, 0.0.9, 0.0.10, 0.0.11, 0.0.12, 0.0.13, 0.0.14, 0.0.15, 0.0.16, 0.0.17, 0.0.18, 0.0.19, 0.0.20, 0.0.21, 0.0.22, 0.0.23, 0.0.24, 0.0.25, 0.0.26, 0.0.27)
ERROR: No matching distribution found for langchain==0.0.101

The langchain version is [0.0.1-0.0.27], and the version 0.0.101 in the requirements.txt file is invalid. fixing to version 0.0.10