### PR TITLE
fix python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git clone https://github.com/microsoft/visual-chatgpt.git
 cd visual-chatgpt
 
 # create a new environment
-conda create -n visgpt python=3.8
+conda create -n visgpt python=3.9
 
 # activate the new environment
 conda activate visgpt


### PR DESCRIPTION
It doesn`t work in python3.8, bacaseuse the requirement package 'langchain==0.0.101' requires python version in '<4.0, >=3.8.1'

It`s error info when i try to install langchain==0.0.101 in python3.8.0: 
ERROR: Package 'langchain' requires a different Python: 3.8.0 not in '<4.0,>=3.8.1'  

so it should be work in python3.9