### PR TITLE
Add CoT prompt to improve nlp+vision task.

### DIFF
--- a/visual_chatgpt.py
+++ b/visual_chatgpt.py
@@ -67,7 +67,8 @@ Previous conversation history:
 New input: {input}
 Since Visual ChatGPT is a text language model, Visual ChatGPT must use tools to observe images rather than imagination.
 The thoughts and observations are only visible for Visual ChatGPT, Visual ChatGPT should remember to repeat important information in the final response for Human. 
-Thought: Do I need to use a tool? {agent_scratchpad}"""
+Thought: Do I need to use a tool? {agent_scratchpad} Let's think step by step.
+"""
 
 os.makedirs('image', exist_ok=True)
 
@@ -1011,7 +1012,7 @@ class ConversationBot:
 
     def run_text(self, text, state):
         self.agent.memory.buffer = cut_dialogue_history(self.agent.memory.buffer, keep_last_n_words=500)
-        res = self.agent({"input": text})
+        res = self.agent({"input": text.strip()})
         res['output'] = res['output'].replace("\\", "/")
         response = re.sub('(image/\S*png)', lambda m: f'![](/file={m.group(0)})*{m.group(0)}*', res['output'])
         state = state + [(text, response)]


### PR DESCRIPTION
Currently visual-chatgpt will sometimes fail in some nlp+visual tasks, such as first summarizing the input and then generating a related picture. After intensive trials, I found that adding simple CoT prompts (i.e., Let's think step by step.) can make improvements on this kind of task.

Task: randomly select some consecutive paragraphs from BBC news and ask visual-chatgpt to summarize the content and then generate a related picture.

Case study:
- For the cases where VFM can be correctly called by LLM, adding CoT doesn't have observable side-effects.
  - source: https://www.bbc.com/news/entertainment-arts-65092306
    - before:
    ![image](https://user-images.githubusercontent.com/14221971/228510064-84e80fdd-7c7d-4082-9c36-59e52446510d.png)
    - after:
    ![image](https://user-images.githubusercontent.com/14221971/228510123-2e9fef50-fe29-4222-a570-a28ed1e38c37.png)
- For the bad cases where VFM is not called by LLM, adding CoT enables more accurate judgment and parsing.
  - https://www.bbc.com/news/technology-65102150
    - before:
    ![image](https://user-images.githubusercontent.com/14221971/228509130-abef51c7-0675-435e-b9f1-cb4eb5ed04d5.png)
    - after:
    ![image](https://user-images.githubusercontent.com/14221971/228509941-dd52b68b-9f53-4961-a8bc-748f4740b90c.png)
- In the below case, the LLM believes that it requires calling VFM. It indeed generates the corresponding instruction, but it cannot be successfully parsed and translated into actual execution actions. After adding CoT, the output from LLM will be easier to parse.
  - source: https://www.bbc.com/news/world-europe-65107800
    - before:
    ![image](https://user-images.githubusercontent.com/14221971/228510570-6a9cd8c2-6e8b-4520-b85d-63fba36395c0.png)
    - after:
    ![image](https://user-images.githubusercontent.com/14221971/228511311-add13c9a-cba1-4f85-87da-88c1109ffb05.png)