### PR TITLE
Support for image search engines

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ accelerate
 addict
 albumentations
 basicsr
+clip-retrieval
 controlnet-aux
 diffusers
 einops

--- a/search.py
+++ b/search.py
@@ -1,0 +1,61 @@
+import requests
+
+from clip_retrieval.clip_client import ClipClient, Modality
+from PIL import Image
+
+from utils import get_image_name, get_new_image_name, prompts
+
+
+def download_image(img_url, img_path):
+    img_stream = requests.get(img_url, stream=True)
+    if img_stream.status_code == 200:
+        img = Image.open(img_stream.raw)
+        img.save(img_path, format="png")
+        return img_path
+
+
+def download_best_available(search_result, result_img_path):
+    if search_result:
+        img_path = download_image(search_result[0]["url"], result_img_path)
+        return img_path if img_path else download_best_available(search_result[1:], result_img_path)
+
+
+class SearchSupport:
+    def __init__(self):
+        self.client = ClipClient(
+            url="https://knn.laion.ai/knn-service",
+            indice_name="laion5B-L-14",
+            modality=Modality.IMAGE,
+            aesthetic_score=0,
+            aesthetic_weight=0.0,
+            num_images=10,
+        )
+
+
+class ImageSearch(SearchSupport):
+    def __init__(self, *args, **kwargs):
+        print("Initializing Image Search")
+        super().__init__()
+
+    @prompts(name="Search Image That Matches User Input Text",
+             description="useful when you want to search an image that matches a given description. "
+                         "like: find an image that contains certain objects with certain properties, "
+                         "or refine a previous search with additional criteria. " 
+                         "The input to this tool should be a string, representing the description. ")
+    def inference(self, query_text):
+        search_result = self.client.query(text=query_text)
+        return download_best_available(search_result, get_image_name())
+
+
+class VisualSearch(SearchSupport):
+    def __init__(self, *args, **kwargs):
+        print("Initializing Visual Search")
+        super().__init__()
+
+    @prompts(name="Search Image Visually Similar to an Input Image",
+             description="useful when you want to search an image that is visually similar to an input image. "
+                         "like: find an image visually similar to a generated or modified image. "
+                         "The input to this tool should be a string, representing the input image path. ")
+    def inference(self, query_img_path):
+        search_result = self.client.query(image=query_img_path)
+        return download_best_available(search_result, get_new_image_name(query_img_path, "visual-search"))

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,47 @@
+import os
+import uuid
+
+
+def prompts(name, description):
+    def decorator(func):
+        func.name = name
+        func.description = description
+        return func
+
+    return decorator
+
+
+def cut_dialogue_history(history_memory, keep_last_n_words=500):
+    if history_memory is None or len(history_memory) == 0:
+        return history_memory
+    tokens = history_memory.split()
+    n_tokens = len(tokens)
+    print(f"history_memory:{history_memory}, n_tokens: {n_tokens}")
+    if n_tokens < keep_last_n_words:
+        return history_memory
+    paragraphs = history_memory.split('\n')
+    last_n_tokens = n_tokens
+    while last_n_tokens >= keep_last_n_words:
+        last_n_tokens -= len(paragraphs[0].split(' '))
+        paragraphs = paragraphs[1:]
+    return '\n' + '\n'.join(paragraphs)
+
+
+def get_new_image_name(org_img_name, func_name="update"):
+    head_tail = os.path.split(org_img_name)
+    head = head_tail[0]
+    tail = head_tail[1]
+    name_split = tail.split('.')[0].split('_')
+    this_new_uuid = str(uuid.uuid4())[:4]
+    if len(name_split) == 1:
+        most_org_file_name = name_split[0]
+    else:
+        assert len(name_split) == 4
+        most_org_file_name = name_split[3]
+    recent_prev_file_name = name_split[0]
+    new_file_name = f'{this_new_uuid}_{func_name}_{recent_prev_file_name}_{most_org_file_name}.png'
+    return os.path.join(head, new_file_name)
+
+
+def get_image_name():
+    return os.path.join('image', f"{str(uuid.uuid4())[:8]}.png")

--- a/visual_chatgpt.py
+++ b/visual_chatgpt.py
@@ -4,8 +4,7 @@ import random
 import torch
 import cv2
 import re
-import uuid
-from PIL import Image, ImageDraw, ImageOps
+from PIL import Image, ImageOps
 import math
 import numpy as np
 import argparse
@@ -24,6 +23,9 @@ from langchain.agents.initialize import initialize_agent
 from langchain.agents.tools import Tool
 from langchain.chains.conversation.memory import ConversationBufferMemory
 from langchain.llms.openai import OpenAI
+
+from search import ImageSearch, VisualSearch
+from utils import cut_dialogue_history, get_image_name, get_new_image_name, prompts
 
 VISUAL_CHATGPT_PREFIX = """Visual ChatGPT is designed to be able to assist with a wide range of text and visual related tasks, from answering simple questions to providing in-depth explanations and discussions on a wide range of topics. Visual ChatGPT is able to generate human-like text based on the input it receives, allowing it to engage in natural-sounding conversations and provide responses that are coherent and relevant to the topic at hand.
 
@@ -81,15 +83,6 @@ def seed_everything(seed):
     return seed
 
 
-def prompts(name, description):
-    def decorator(func):
-        func.name = name
-        func.description = description
-        return func
-
-    return decorator
-
-
 def blend_gt2pt(old_image, new_image, sigma=0.15, steps=100):
     new_size = new_image.size
     old_size = old_image.size
@@ -145,39 +138,6 @@ def blend_gt2pt(old_image, new_image, sigma=0.15, steps=100):
     easy_img[pos_h:pos_h + old_size[1], pos_w:pos_w + old_size[0]] = gaussian_gt_img
     gaussian_img = Image.fromarray(easy_img)
     return gaussian_img
-
-
-def cut_dialogue_history(history_memory, keep_last_n_words=500):
-    if history_memory is None or len(history_memory) == 0:
-        return history_memory
-    tokens = history_memory.split()
-    n_tokens = len(tokens)
-    print(f"history_memory:{history_memory}, n_tokens: {n_tokens}")
-    if n_tokens < keep_last_n_words:
-        return history_memory
-    paragraphs = history_memory.split('\n')
-    last_n_tokens = n_tokens
-    while last_n_tokens >= keep_last_n_words:
-        last_n_tokens -= len(paragraphs[0].split(' '))
-        paragraphs = paragraphs[1:]
-    return '\n' + '\n'.join(paragraphs)
-
-
-def get_new_image_name(org_img_name, func_name="update"):
-    head_tail = os.path.split(org_img_name)
-    head = head_tail[0]
-    tail = head_tail[1]
-    name_split = tail.split('.')[0].split('_')
-    this_new_uuid = str(uuid.uuid4())[:4]
-    if len(name_split) == 1:
-        most_org_file_name = name_split[0]
-    else:
-        assert len(name_split) == 4
-        most_org_file_name = name_split[3]
-    recent_prev_file_name = name_split[0]
-    new_file_name = f'{this_new_uuid}_{func_name}_{recent_prev_file_name}_{most_org_file_name}.png'
-    return os.path.join(head, new_file_name)
-
 
 
 class MaskFormer:
@@ -295,7 +255,7 @@ class Text2Image:
                          "like: generate an image of an object or something, or generate an image that includes some objects. "
                          "The input to this tool should be a string, representing the text used to generate image. ")
     def inference(self, text):
-        image_filename = os.path.join('image', f"{str(uuid.uuid4())[:8]}.png")
+        image_filename = get_image_name()
         prompt = text + ', ' + self.a_prompt
         image = self.pipe(prompt, negative_prompt=self.n_prompt).images[0]
         image.save(image_filename)
@@ -1021,7 +981,7 @@ class ConversationBot:
         return state, state
 
     def run_image(self, image, state, txt):
-        image_filename = os.path.join('image', f"{str(uuid.uuid4())[:8]}.png")
+        image_filename = get_image_name()
         print("======>Auto Resize Image...")
         img = Image.open(image.name)
         width, height = img.size
@@ -1046,11 +1006,13 @@ class ConversationBot:
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--load', type=str, default="ImageCaptioning_cuda:0,Text2Image_cuda:0")
+    parser.add_argument('--host', type=str, default="0.0.0.0")
+    parser.add_argument('--port', type=int, default=1015)
     args = parser.parse_args()
     load_dict = {e.split('_')[0].strip(): e.split('_')[1].strip() for e in args.load.split(',')}
     bot = ConversationBot(load_dict=load_dict)
     with gr.Blocks(css="#chatbot .overflow-y-auto{height:500px}") as demo:
-        chatbot = gr.Chatbot(elem_id="chatbot", label="Visual ChatGPT")
+        chatbot = gr.Chatbot(elem_id="chatbot", label="Visual ChatGPT").style(height=800)
         state = gr.State([])
         with gr.Row():
             with gr.Column(scale=0.7):
@@ -1067,4 +1029,4 @@ if __name__ == '__main__':
         clear.click(bot.memory.clear)
         clear.click(lambda: [], None, chatbot)
         clear.click(lambda: [], None, state)
-        demo.launch(server_name="0.0.0.0", server_port=1015)
+        demo.launch(server_name=args.host, server_port=args.port)


### PR DESCRIPTION
This PR adds support for image search in the LAION-5B dataset (both, by image and text query) and makes a few minor refactorings. For example, when starting the demo UI with 

```shell
python visual_chatgpt.py --load="ImageCaptioning_cuda:0,ImageEditing_cuda:1,Text2Image_cuda:2,ImageSearch_,VisualSearch_"
```

you can do something like:

Generate an image and find a visually similar image in the LAION-5B dataset. The generated image is used as query image:

![sample-1](https://user-images.githubusercontent.com/202907/229574595-c9cc6a9f-9208-4838-afd4-47d5b34ccbaa.png)

Search an image in the LAION-5B dataset matching a user-provided description (query text) and then process that image with a visual foundation model:

![sample-2](https://user-images.githubusercontent.com/202907/229574644-3128b7d7-7704-4c1a-9d3c-625b0444b6d4.png)

Instruct Visual ChatGPT to generate an image, caption that image and then search for a LAION-5B image matching the caption. The instruction is decomposed by ChatGPT into three steps: image generation, image captioning and image search by query text:

![sample-3](https://user-images.githubusercontent.com/202907/229574686-3cf19606-08e2-463c-9f7d-ea7068ca0358.png)

These are rather simple examples. You can of course combine the search tools with other VFMs to support more complex image processing and search workflows. 

Although image search engines are not VFMs I still hope this PR adds something useful to the project.