### PR TITLE
Fix Encoding Error when runs on windows with chinese char

### DIFF
--- a/visual_chatgpt.py
+++ b/visual_chatgpt.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import os
 import gradio as gr
 import random


### PR DESCRIPTION
Fix Chinese encoding error:
 File "visual_chatgpt.py", line 75
SyntaxError: Non-UTF-8 code starting with '\xe4' in file visual_chatgpt.py on line 76, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details